### PR TITLE
Add publish skill for uploading files to Cloudflare R2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "1.0.0",
   "author": { "name": "jcottam" },
   "license": "MIT",
-  "skills": ["./skills/engineering/ship", "./skills/thinking/advisor"]
+  "skills": ["./skills/engineering/ship", "./skills/thinking/advisor", "./skills/publishing/publish"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.wrangler

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.3.0",
+    "date": "2026-05-16",
+    "pr": {
+      "number": 3,
+      "title": "Add publish skill for uploading files to Cloudflare R2",
+      "url": "https://github.com/jcottam/agent-resources/pull/3"
+    },
+    "changes": {
+      "features": [
+        "Added publish skill for uploading files to Cloudflare R2 and sharing via public URL"
+      ]
+    }
+  },
+  {
     "version": "0.2.0",
     "date": "2026-05-14",
     "pr": {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ npx skills update
 |-------|-------------|
 | [ship](./skills/engineering/ship/SKILL.md) | Validate a branch, run quality gates, update documentation and changelog, and open a pull request. |
 
+### Publishing
+
+| Skill | Description |
+|-------|-------------|
+| [publish](./skills/publishing/publish/SKILL.md) | Upload files to Cloudflare R2 and return a shareable public URL with slug naming, clipboard copy, and publish history. |
+
 ### Thinking
 
 | Skill | Description |

--- a/skills/publishing/publish/SKILL.md
+++ b/skills/publishing/publish/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: publish
+description: >-
+  Upload files to Cloudflare R2 and return a shareable public URL. Supports any
+  file type (HTML, images, PDFs, etc.) with automatic slug generation, clipboard
+  copy, and publish history tracking. Use when the user says "publish",
+  "publish this", "share this file", "upload to R2", "make this public",
+  "get a shareable link", "host this", "deploy this file", "put this online",
+  or any variation of wanting to make a file publicly accessible via URL.
+license: MIT
+metadata:
+  author: jcottam
+  version: "1.0.0"
+---
+
+# Publish
+
+Upload any file to Cloudflare R2 and get back a shareable public URL.
+
+`SCRIPTS` below refers to the `scripts/` directory next to this file.
+
+## Prerequisites
+
+- **Node.js** (for `npx wrangler`)
+- **Cloudflare account** with an R2 bucket that has public access enabled
+- **Wrangler auth** via one of:
+  - `wrangler login` (interactive OAuth -- run once, persists in `~/.wrangler`)
+  - `CLOUDFLARE_API_TOKEN` environment variable
+
+## Step 1 — Check configuration
+
+Look for `~/.publish.json`. If it doesn't exist, run `$SCRIPTS/setup.sh` and walk the user through the prompts. The setup script creates the config file with:
+
+```json
+{
+  "bucket": "my-bucket-name",
+  "publicBaseUrl": "https://pub-xxx.r2.dev"
+}
+```
+
+If the file exists, read it and parse the `bucket` and `publicBaseUrl` values. Both are required.
+
+## Step 2 — Identify the asset
+
+Determine what file to publish from context:
+
+1. If the user specified a file path, use that.
+2. If the user said "publish this" without a path, check for:
+   - A file the user is currently viewing or recently created
+   - A `.canvas.tsx` output or generated HTML file from the current session
+3. Verify the file exists before proceeding. If ambiguous, ask the user to clarify.
+
+## Step 3 — Generate the key
+
+Decide the R2 object key (the path within the bucket):
+
+- **Default**: derive a readable slug from the filename.
+  - Strip extension, lowercase, replace spaces and special characters with hyphens
+  - Append today's date: `my-report-2026-05-15`
+  - Re-attach the original file extension
+  - Example: `Sales Report Q1.html` becomes `sales-report-q1-2026-05-15.html`
+- **User override**: if the user provided a custom name, use it instead (sanitized).
+- **Collision check**: scan `~/.publish-history.json` for the key. If it exists, ask the user whether to overwrite or append a suffix (`-2`, `-3`, etc.).
+
+## Step 4 — Publish
+
+Run the publish script:
+
+```bash
+$SCRIPTS/publish.sh <file-path> [--key <custom-key>]
+```
+
+The script:
+1. Reads `~/.publish.json` for bucket name and public URL base
+2. Detects the content type from the file extension
+3. Uploads via `npx wrangler r2 object put <bucket>/<key> --file <path> --content-type <type>`
+4. Constructs the public URL: `<publicBaseUrl>/<key>`
+5. Copies the URL to the clipboard (`pbcopy` on macOS, `xclip`/`xsel` on Linux)
+6. Appends an entry to `~/.publish-history.json`
+7. Outputs JSON with `url`, `key`, `contentType`, `size`, and `publishedAt`
+
+If the script exits non-zero, report the error to the user. Common issues:
+- **Not authenticated**: suggest running `wrangler login` or setting `CLOUDFLARE_API_TOKEN`
+- **Bucket not found**: confirm the bucket name in `~/.publish.json` and that public access is enabled
+- **File not found**: re-check the file path
+
+## Step 5 — Report
+
+After a successful publish:
+
+1. Print the public URL prominently.
+2. Confirm the URL was copied to the clipboard.
+3. Mention the entry was added to publish history.
+
+Example output:
+
+```
+Published: https://pub-xxx.r2.dev/sales-report-q1-2026-05-15.html
+Copied to clipboard.
+```
+
+## Publish history
+
+Use `$SCRIPTS/history.sh` to interact with the local publish history at `~/.publish-history.json`.
+
+| Command | Description |
+|---------|-------------|
+| `history.sh list` | Show the 10 most recent publishes |
+| `history.sh list --all` | Show all publishes |
+| `history.sh search <query>` | Filter entries by key or local path |
+| `history.sh prune` | Remove entries whose R2 objects no longer exist |
+
+When the user asks to see their publish history, list recent uploads, or find a previously published file, use the appropriate history command.
+
+## Custom domains
+
+For setting up a custom domain instead of the default `r2.dev` URL, see [references/custom-domain.md](references/custom-domain.md).

--- a/skills/publishing/publish/references/custom-domain.md
+++ b/skills/publishing/publish/references/custom-domain.md
@@ -1,0 +1,69 @@
+# Custom Domain for R2
+
+Replace the default `pub-xxx.r2.dev` URL with your own domain (e.g., `assets.yourdomain.com`).
+
+## Steps
+
+### 1. Connect the domain in Cloudflare
+
+1. Open the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Navigate to **R2 Object Storage** > your bucket > **Settings** > **Public access**.
+3. Under **Custom Domains**, click **Connect Domain**.
+4. Enter your subdomain (e.g., `assets.yourdomain.com`).
+5. Cloudflare automatically creates the required DNS record. Confirm and wait for the SSL certificate to provision (usually under a minute).
+
+Your domain must already be on Cloudflare DNS (orange-clouded) for this to work.
+
+### 2. Update your publish config
+
+Edit `~/.publish.json` and change `publicBaseUrl` to your custom domain:
+
+```json
+{
+  "bucket": "my-bucket",
+  "publicBaseUrl": "https://assets.yourdomain.com"
+}
+```
+
+All future publishes will use this domain. Previously published URLs at `r2.dev` continue to work unless you disable the R2.dev subdomain in the dashboard.
+
+### 3. (Optional) Disable the r2.dev URL
+
+If you want all access to go through your custom domain:
+
+1. In the bucket settings under **Public access**, find the **R2.dev subdomain** toggle.
+2. Disable it.
+
+Existing links using the `r2.dev` URL will stop working after this.
+
+## Cache and headers
+
+Custom domains on R2 automatically go through Cloudflare's CDN. You can configure cache behavior and custom headers with **Cache Rules** and **Transform Rules** in the Cloudflare dashboard under your domain's settings.
+
+Common headers to set via Transform Rules:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Cache-Control` | `public, max-age=31536000, immutable` | Long-lived caching for hashed assets |
+| `Cache-Control` | `public, max-age=3600` | Short caching for HTML that may change |
+| `X-Content-Type-Options` | `nosniff` | Prevent MIME-type sniffing |
+
+## CORS
+
+If published assets need to be loaded from other origins (e.g., embedding an HTML file in an iframe), configure CORS on the bucket:
+
+1. In the bucket settings, find **CORS Policy**.
+2. Add a rule allowing the origins you need, or use `*` for unrestricted access.
+
+Example policy:
+
+```json
+[
+  {
+    "AllowedOrigins": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "MaxAgeSeconds": 86400
+  }
+]
+```

--- a/skills/publishing/publish/scripts/history.sh
+++ b/skills/publishing/publish/scripts/history.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HISTORY_FILE="$HOME/.publish-history.json"
+
+usage() {
+  echo "Usage: history.sh <command> [options]"
+  echo ""
+  echo "Commands:"
+  echo "  list [--all]       Show recent publishes (default: last 10)"
+  echo "  search <query>     Filter entries by key or local path"
+  echo "  prune              Remove entries whose R2 objects no longer exist"
+  echo "  clear              Delete all history"
+  exit 1
+}
+
+ensure_history() {
+  if [[ ! -f "$HISTORY_FILE" ]]; then
+    echo "No publish history found."
+    exit 0
+  fi
+}
+
+CMD="${1:-}"
+shift || true
+
+case "$CMD" in
+  list)
+    ensure_history
+    SHOW_ALL="false"
+    if [[ "${1:-}" == "--all" ]]; then
+      SHOW_ALL="true"
+    fi
+    python3 -c "
+import json, sys
+
+with open(sys.argv[1]) as f:
+    history = json.load(f)
+
+if not history:
+    print('No publish history.')
+    sys.exit(0)
+
+show_all = sys.argv[2] == 'true'
+entries = history if show_all else history[-10:]
+
+if not show_all and len(history) > 10:
+    print(f'Showing last 10 of {len(history)} entries (use --all to see all)\n')
+
+for i, entry in enumerate(entries):
+    size_kb = entry.get('size', 0) / 1024
+    print(f\"{entry['publishedAt']}  {entry['key']}\")
+    print(f\"  URL:  {entry['url']}\")
+    print(f\"  Type: {entry['contentType']}  Size: {size_kb:.1f} KB\")
+    if i < len(entries) - 1:
+        print()
+" "$HISTORY_FILE" "$SHOW_ALL"
+    ;;
+
+  search)
+    ensure_history
+    QUERY="${1:-}"
+    if [[ -z "$QUERY" ]]; then
+      echo "Error: search query is required" >&2
+      echo "Usage: history.sh search <query>" >&2
+      exit 1
+    fi
+    python3 -c "
+import json, sys
+
+query = sys.argv[2].lower()
+with open(sys.argv[1]) as f:
+    history = json.load(f)
+
+matches = [e for e in history if query in e.get('key','').lower() or query in e.get('localPath','').lower() or query in e.get('url','').lower()]
+
+if not matches:
+    print(f'No entries matching \"{sys.argv[2]}\".')
+    sys.exit(0)
+
+print(f'Found {len(matches)} match(es):\n')
+for i, entry in enumerate(matches):
+    size_kb = entry.get('size', 0) / 1024
+    print(f\"{entry['publishedAt']}  {entry['key']}\")
+    print(f\"  URL:   {entry['url']}\")
+    print(f\"  From:  {entry.get('localPath', 'unknown')}\")
+    print(f\"  Type:  {entry['contentType']}  Size: {size_kb:.1f} KB\")
+    if i < len(matches) - 1:
+        print()
+" "$HISTORY_FILE" "$QUERY"
+    ;;
+
+  prune)
+    ensure_history
+    echo "Reading config for bucket name..."
+
+    CONFIG_FILE="$HOME/.publish.json"
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+      echo "Error: config not found at $CONFIG_FILE" >&2
+      echo "Run setup.sh first." >&2
+      exit 1
+    fi
+
+    BUCKET=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['bucket'])" "$CONFIG_FILE")
+
+    python3 -c "
+import json, subprocess, sys
+
+bucket = sys.argv[2]
+with open(sys.argv[1]) as f:
+    history = json.load(f)
+
+if not history:
+    print('History is empty.')
+    sys.exit(0)
+
+print(f'Checking {len(history)} entries against R2...')
+kept = []
+removed = 0
+
+for entry in history:
+    key = entry['key']
+    result = subprocess.run(
+        ['npx', 'wrangler', 'r2', 'object', 'get', f'{bucket}/{key}', '--file', '/dev/null'],
+        capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        kept.append(entry)
+    else:
+        removed += 1
+        print(f'  Removed: {key}')
+
+with open(sys.argv[1], 'w') as f:
+    json.dump(kept, f, indent=2)
+
+print(f'\nPruned {removed} entries. {len(kept)} remaining.')
+" "$HISTORY_FILE" "$BUCKET"
+    ;;
+
+  clear)
+    ensure_history
+    read -rp "Delete all publish history? [y/N] " confirm
+    if [[ "$confirm" =~ ^[Yy]$ ]]; then
+      rm "$HISTORY_FILE"
+      echo "History cleared."
+    else
+      echo "Cancelled."
+    fi
+    ;;
+
+  *)
+    usage
+    ;;
+esac

--- a/skills/publishing/publish/scripts/publish.sh
+++ b/skills/publishing/publish/scripts/publish.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="$HOME/.publish.json"
+HISTORY_FILE="$HOME/.publish-history.json"
+
+usage() {
+  echo "Usage: publish.sh <file-path> [--key <custom-key>]"
+  echo ""
+  echo "Upload a file to Cloudflare R2 and return a public URL."
+  echo ""
+  echo "Options:"
+  echo "  --key <name>   Override the auto-generated object key"
+  exit 1
+}
+
+# --- Parse arguments ---
+
+FILE_PATH=""
+CUSTOM_KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --key)
+      CUSTOM_KEY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      if [[ -z "$FILE_PATH" ]]; then
+        FILE_PATH="$1"
+      else
+        echo "Error: unexpected argument '$1'" >&2
+        usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FILE_PATH" ]]; then
+  echo "Error: file path is required" >&2
+  usage
+fi
+
+if [[ ! -f "$FILE_PATH" ]]; then
+  echo "Error: file not found: $FILE_PATH" >&2
+  exit 1
+fi
+
+# --- Read config ---
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Error: config not found at $CONFIG_FILE" >&2
+  echo "Run setup.sh first to configure your R2 bucket." >&2
+  exit 1
+fi
+
+BUCKET=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['bucket'])" "$CONFIG_FILE" 2>/dev/null)
+PUBLIC_BASE_URL=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['publicBaseUrl'])" "$CONFIG_FILE" 2>/dev/null)
+
+if [[ -z "$BUCKET" || -z "$PUBLIC_BASE_URL" ]]; then
+  echo "Error: ~/.publish.json must contain 'bucket' and 'publicBaseUrl'" >&2
+  exit 1
+fi
+
+# Strip trailing slash from base URL
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL%/}"
+
+# --- Detect content type ---
+
+detect_content_type() {
+  local ext="${1##*.}"
+  ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
+  case "$ext" in
+    html|htm)   echo "text/html" ;;
+    css)        echo "text/css" ;;
+    js|mjs)     echo "application/javascript" ;;
+    json)       echo "application/json" ;;
+    xml)        echo "application/xml" ;;
+    svg)        echo "image/svg+xml" ;;
+    png)        echo "image/png" ;;
+    jpg|jpeg)   echo "image/jpeg" ;;
+    gif)        echo "image/gif" ;;
+    webp)       echo "image/webp" ;;
+    ico)        echo "image/x-icon" ;;
+    pdf)        echo "application/pdf" ;;
+    zip)        echo "application/zip" ;;
+    gz|gzip)    echo "application/gzip" ;;
+    tar)        echo "application/x-tar" ;;
+    txt)        echo "text/plain" ;;
+    md)         echo "text/markdown" ;;
+    csv)        echo "text/csv" ;;
+    woff)       echo "font/woff" ;;
+    woff2)      echo "font/woff2" ;;
+    ttf)        echo "font/ttf" ;;
+    otf)        echo "font/otf" ;;
+    mp4)        echo "video/mp4" ;;
+    webm)       echo "video/webm" ;;
+    mp3)        echo "audio/mpeg" ;;
+    wav)        echo "audio/wav" ;;
+    ogg)        echo "audio/ogg" ;;
+    *)          echo "application/octet-stream" ;;
+  esac
+}
+
+# --- Generate key ---
+
+generate_slug() {
+  local filename
+  filename=$(basename "$1")
+  local name="${filename%.*}"
+  local ext="${filename##*.}"
+
+  # Lowercase, replace non-alphanumeric with hyphens, collapse multiples, trim edges
+  local slug
+  slug=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//')
+
+  local today
+  today=$(date +%Y-%m-%d)
+
+  echo "${slug}-${today}.${ext}"
+}
+
+if [[ -n "$CUSTOM_KEY" ]]; then
+  KEY="$CUSTOM_KEY"
+else
+  KEY=$(generate_slug "$FILE_PATH")
+fi
+
+CONTENT_TYPE=$(detect_content_type "$FILE_PATH")
+FILE_SIZE=$(wc -c < "$FILE_PATH" | tr -d ' ')
+
+# --- Upload ---
+
+npx wrangler r2 object put "${BUCKET}/${KEY}" \
+  --file "$FILE_PATH" \
+  --content-type "$CONTENT_TYPE" >/dev/null 2>&1
+
+PUBLIC_URL="${PUBLIC_BASE_URL}/${KEY}"
+
+# --- Clipboard ---
+
+copy_to_clipboard() {
+  if command -v pbcopy &>/dev/null; then
+    echo -n "$1" | pbcopy
+    return 0
+  elif command -v xclip &>/dev/null; then
+    echo -n "$1" | xclip -selection clipboard
+    return 0
+  elif command -v xsel &>/dev/null; then
+    echo -n "$1" | xsel --clipboard --input
+    return 0
+  fi
+  return 1
+}
+
+CLIPBOARD_OK="false"
+if copy_to_clipboard "$PUBLIC_URL"; then
+  CLIPBOARD_OK="true"
+fi
+
+# --- History ---
+
+PUBLISHED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ABS_PATH=$(cd "$(dirname "$FILE_PATH")" && pwd)/$(basename "$FILE_PATH")
+
+ENTRY=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'key': sys.argv[1],
+    'localPath': sys.argv[2],
+    'url': sys.argv[3],
+    'contentType': sys.argv[4],
+    'size': int(sys.argv[5]),
+    'publishedAt': sys.argv[6]
+}))
+" "$KEY" "$ABS_PATH" "$PUBLIC_URL" "$CONTENT_TYPE" "$FILE_SIZE" "$PUBLISHED_AT")
+
+if [[ -f "$HISTORY_FILE" ]]; then
+  python3 -c "
+import json, sys
+entry = json.loads(sys.argv[1])
+with open(sys.argv[2], 'r') as f:
+    history = json.load(f)
+history.append(entry)
+with open(sys.argv[2], 'w') as f:
+    json.dump(history, f, indent=2)
+" "$ENTRY" "$HISTORY_FILE"
+else
+  python3 -c "
+import json, sys
+entry = json.loads(sys.argv[1])
+with open(sys.argv[2], 'w') as f:
+    json.dump([entry], f, indent=2)
+" "$ENTRY" "$HISTORY_FILE"
+fi
+
+# --- Output ---
+
+python3 -c "
+import json, sys
+print(json.dumps({
+    'url': sys.argv[1],
+    'key': sys.argv[2],
+    'contentType': sys.argv[3],
+    'size': int(sys.argv[4]),
+    'publishedAt': sys.argv[5],
+    'clipboard': sys.argv[6] == 'true'
+}, indent=2))
+" "$PUBLIC_URL" "$KEY" "$CONTENT_TYPE" "$FILE_SIZE" "$PUBLISHED_AT" "$CLIPBOARD_OK"

--- a/skills/publishing/publish/scripts/setup.sh
+++ b/skills/publishing/publish/scripts/setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="$HOME/.publish.json"
+
+echo "=== Publish Skill Setup ==="
+echo ""
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "Existing config found at $CONFIG_FILE:"
+  cat "$CONFIG_FILE"
+  echo ""
+  read -rp "Overwrite? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Setup cancelled."
+    exit 0
+  fi
+  echo ""
+fi
+
+# --- Bucket name ---
+
+read -rp "R2 bucket name: " BUCKET
+if [[ -z "$BUCKET" ]]; then
+  echo "Error: bucket name is required" >&2
+  exit 1
+fi
+
+# --- Public base URL ---
+
+echo ""
+echo "Enter the public base URL for your bucket."
+echo "This is the URL prefix used to construct shareable links."
+echo ""
+echo "Examples:"
+echo "  https://pub-abc123.r2.dev          (R2 public bucket URL)"
+echo "  https://assets.yourdomain.com      (custom domain)"
+echo ""
+
+read -rp "Public base URL: " PUBLIC_BASE_URL
+if [[ -z "$PUBLIC_BASE_URL" ]]; then
+  echo "Error: public base URL is required" >&2
+  exit 1
+fi
+
+# Strip trailing slash
+PUBLIC_BASE_URL="${PUBLIC_BASE_URL%/}"
+
+# --- Write config ---
+
+python3 -c "
+import json, sys
+config = {
+    'bucket': sys.argv[1],
+    'publicBaseUrl': sys.argv[2]
+}
+with open(sys.argv[3], 'w') as f:
+    json.dump(config, f, indent=2)
+print()
+print('Config written to ' + sys.argv[3])
+" "$BUCKET" "$PUBLIC_BASE_URL" "$CONFIG_FILE"
+
+echo ""
+
+# --- Check wrangler auth ---
+
+echo "Checking wrangler authentication..."
+if npx wrangler whoami &>/dev/null 2>&1; then
+  echo "Wrangler is authenticated."
+else
+  echo ""
+  echo "Wrangler is not authenticated. You have two options:"
+  echo ""
+  echo "  1. Run: npx wrangler login"
+  echo "     (Interactive OAuth -- opens your browser)"
+  echo ""
+  echo "  2. Set the CLOUDFLARE_API_TOKEN environment variable"
+  echo "     (Create a token at https://dash.cloudflare.com/profile/api-tokens)"
+  echo ""
+fi
+
+echo ""
+echo "Setup complete. You can now use 'publish' to upload files."


### PR DESCRIPTION
## Summary

- Added new **publish** skill that uploads any file to a Cloudflare R2 bucket via the wrangler CLI and returns a shareable public URL.
- Includes slug-based naming, content-type detection for 30+ file types, clipboard copy, and local publish history tracking.
- Ships with a first-time setup wizard (`setup.sh`), history management (`history.sh`), and a custom domain reference guide.

## Test plan

- [ ] Run `setup.sh` to create `~/.publish.json` with a valid R2 bucket
- [ ] Publish an HTML file and verify the returned URL is accessible
- [ ] Publish with `--key` override and confirm the custom slug is used
- [ ] Run `history.sh list` and verify the entry appears
- [ ] Run `history.sh search` with a partial key and confirm match
- [ ] Verify the URL is copied to clipboard after publish