### PR TITLE
Add prerequisites check to ship skill

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "0.4.0",
+    "date": "2026-05-16",
+    "pr": {
+      "number": 4,
+      "title": "Add prerequisites check to ship skill",
+      "url": "https://github.com/jcottam/agent-resources/pull/4"
+    },
+    "changes": {
+      "features": [
+        "Added prerequisites check to the ship skill that verifies git, gh, jq, and node are installed and authenticated before running"
+      ]
+    }
+  },
+  {
     "version": "0.3.0",
     "date": "2026-05-16",
     "pr": {

--- a/skills/engineering/ship/SKILL.md
+++ b/skills/engineering/ship/SKILL.md
@@ -13,6 +13,21 @@ Pre-flight checklist that validates the branch, runs quality gates, updates docu
 
 `SCRIPTS` below refers to the `scripts/` directory next to this file.
 
+## Step 0 — Prerequisites
+
+Verify that all required CLI tools are installed and authenticated before proceeding.
+
+Run `command -v git && command -v gh && command -v jq && command -v node` to check availability. If any tool is missing, stop and tell the user which tool(s) need to be installed.
+
+| Tool   | Purpose                          | Install hint                                      |
+| ------ | -------------------------------- | ------------------------------------------------- |
+| `git`  | Branch ops, commits, push        | https://git-scm.com/downloads                     |
+| `gh`   | GitHub PR create/view/edit       | `brew install gh` or https://cli.github.com       |
+| `jq`   | JSON parsing in shell scripts    | `brew install jq` or https://jqlang.github.io/jq  |
+| `node` | Inline JS for changelog and gates| https://nodejs.org                                |
+
+Then run `gh auth status` to confirm the GitHub CLI is authenticated. If it reports no active account, stop and instruct the user to run `gh auth login` first.
+
 ## Step 1 — Git health check
 
 Run `$SCRIPTS/preflight.sh` and parse the JSON output.


### PR DESCRIPTION
## Summary

- Added a Step 0 — Prerequisites section to the ship skill that verifies `git`, `gh`, `jq`, and `node` are installed before running the workflow
- Checks `gh auth status` to catch unauthenticated GitHub CLI early
- Provides install hints for each missing tool

## Test plan

- [ ] Run the ship skill on a machine with all tools installed — should pass Step 0 silently
- [ ] Remove `jq` from PATH and run — should stop with a clear error and install hint
- [ ] Run with `gh` installed but unauthenticated — should stop and instruct to run `gh auth login`