### PR TITLE
fix(publish): add --remote flag and require Wrangler CLI

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "0.4.1",
+    "date": "2026-05-16",
+    "pr": {
+      "number": 5,
+      "title": "fix(publish): add --remote flag and require Wrangler CLI",
+      "url": "https://github.com/jcottam/agent-resources/pull/5"
+    },
+    "changes": {
+      "fixes": [
+        "Fixed publish skill uploading to local R2 simulator instead of remote Cloudflare bucket by adding the required --remote flag to all wrangler commands"
+      ],
+      "improvements": [
+        "Switched from npx to direct wrangler invocation for faster, more reliable uploads",
+        "Added Wrangler installation check and auto-install prompt to setup script",
+        "Surfaced upload errors instead of silencing them"
+      ]
+    }
+  },
+  {
     "version": "0.4.0",
     "date": "2026-05-16",
     "pr": {

--- a/skills/publishing/publish/SKILL.md
+++ b/skills/publishing/publish/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: jcottam
-  version: "1.0.0"
+  version: "1.1.0"
 ---
 
 # Publish
@@ -21,13 +21,39 @@ Upload any file to Cloudflare R2 and get back a shareable public URL.
 
 ## Prerequisites
 
-- **Node.js** (for `npx wrangler`)
-- **Cloudflare account** with an R2 bucket that has public access enabled
-- **Wrangler auth** via one of:
-  - `wrangler login` (interactive OAuth -- run once, persists in `~/.wrangler`)
+- **Wrangler CLI** — the Cloudflare developer CLI used for all R2 operations
+- **Cloudflare account** with an R2 bucket that has public access enabled (r2.dev subdomain or custom domain)
+- **Wrangler authenticated** via one of:
+  - `wrangler login` (interactive OAuth — run once, token persists in `~/.wrangler`)
   - `CLOUDFLARE_API_TOKEN` environment variable
 
-## Step 1 — Check configuration
+## Step 1 — Check prerequisites
+
+### Wrangler installation
+
+Check if `wrangler` is available:
+
+```bash
+wrangler --version
+```
+
+If not installed, install it globally:
+
+```bash
+npm install -g wrangler
+```
+
+### Wrangler authentication
+
+Verify auth status:
+
+```bash
+wrangler whoami
+```
+
+If not authenticated, the user must run `wrangler login` interactively (opens a browser for OAuth). This is a one-time step.
+
+### Publish configuration
 
 Look for `~/.publish.json`. If it doesn't exist, run `$SCRIPTS/setup.sh` and walk the user through the prompts. The setup script creates the config file with:
 
@@ -73,14 +99,17 @@ $SCRIPTS/publish.sh <file-path> [--key <custom-key>]
 The script:
 1. Reads `~/.publish.json` for bucket name and public URL base
 2. Detects the content type from the file extension
-3. Uploads via `npx wrangler r2 object put <bucket>/<key> --file <path> --content-type <type>`
+3. Uploads via `wrangler r2 object put <bucket>/<key> --file <path> --content-type <type> --remote`
 4. Constructs the public URL: `<publicBaseUrl>/<key>`
 5. Copies the URL to the clipboard (`pbcopy` on macOS, `xclip`/`xsel` on Linux)
 6. Appends an entry to `~/.publish-history.json`
 7. Outputs JSON with `url`, `key`, `contentType`, `size`, and `publishedAt`
 
+**Important:** The `--remote` flag is required. Without it, Wrangler uploads to a local R2 simulator instead of the actual Cloudflare R2 bucket.
+
 If the script exits non-zero, report the error to the user. Common issues:
-- **Not authenticated**: suggest running `wrangler login` or setting `CLOUDFLARE_API_TOKEN`
+- **Wrangler not installed**: suggest `npm install -g wrangler`
+- **Not authenticated**: suggest running `wrangler login`
 - **Bucket not found**: confirm the bucket name in `~/.publish.json` and that public access is enabled
 - **File not found**: re-check the file path
 

--- a/skills/publishing/publish/scripts/history.sh
+++ b/skills/publishing/publish/scripts/history.sh
@@ -92,7 +92,12 @@ for i, entry in enumerate(matches):
 
   prune)
     ensure_history
-    echo "Reading config for bucket name..."
+
+    if ! command -v wrangler &>/dev/null; then
+      echo "Error: wrangler CLI is not installed" >&2
+      echo "Install it with: npm install -g wrangler" >&2
+      exit 1
+    fi
 
     CONFIG_FILE="$HOME/.publish.json"
     if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -121,7 +126,7 @@ removed = 0
 for entry in history:
     key = entry['key']
     result = subprocess.run(
-        ['npx', 'wrangler', 'r2', 'object', 'get', f'{bucket}/{key}', '--file', '/dev/null'],
+        ['wrangler', 'r2', 'object', 'get', f'{bucket}/{key}', '--file', '/dev/null', '--remote'],
         capture_output=True, text=True
     )
     if result.returncode == 0:

--- a/skills/publishing/publish/scripts/publish.sh
+++ b/skills/publishing/publish/scripts/publish.sh
@@ -50,6 +50,14 @@ if [[ ! -f "$FILE_PATH" ]]; then
   exit 1
 fi
 
+# --- Check Wrangler ---
+
+if ! command -v wrangler &>/dev/null; then
+  echo "Error: wrangler CLI is not installed" >&2
+  echo "Install it with: npm install -g wrangler" >&2
+  exit 1
+fi
+
 # --- Read config ---
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -114,7 +122,6 @@ generate_slug() {
   local name="${filename%.*}"
   local ext="${filename##*.}"
 
-  # Lowercase, replace non-alphanumeric with hyphens, collapse multiples, trim edges
   local slug
   slug=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//')
 
@@ -133,11 +140,15 @@ fi
 CONTENT_TYPE=$(detect_content_type "$FILE_PATH")
 FILE_SIZE=$(wc -c < "$FILE_PATH" | tr -d ' ')
 
-# --- Upload ---
+# --- Upload to remote R2 ---
 
-npx wrangler r2 object put "${BUCKET}/${KEY}" \
+if ! wrangler r2 object put "${BUCKET}/${KEY}" \
   --file "$FILE_PATH" \
-  --content-type "$CONTENT_TYPE" >/dev/null 2>&1
+  --content-type "$CONTENT_TYPE" \
+  --remote 2>&1; then
+  echo "Error: upload failed" >&2
+  exit 1
+fi
 
 PUBLIC_URL="${PUBLIC_BASE_URL}/${KEY}"
 

--- a/skills/publishing/publish/scripts/setup.sh
+++ b/skills/publishing/publish/scripts/setup.sh
@@ -6,6 +6,29 @@ CONFIG_FILE="$HOME/.publish.json"
 echo "=== Publish Skill Setup ==="
 echo ""
 
+# --- Check Wrangler ---
+
+if ! command -v wrangler &>/dev/null; then
+  echo "Wrangler CLI is not installed."
+  echo ""
+  read -rp "Install wrangler globally via npm? [Y/n] " install_confirm
+  if [[ "$install_confirm" =~ ^[Nn]$ ]]; then
+    echo ""
+    echo "Wrangler is required. Install it manually with:"
+    echo "  npm install -g wrangler"
+    exit 1
+  fi
+  echo ""
+  echo "Installing wrangler..."
+  npm install -g wrangler
+  echo ""
+fi
+
+echo "Wrangler $(wrangler --version 2>&1 | head -1)"
+echo ""
+
+# --- Check existing config ---
+
 if [[ -f "$CONFIG_FILE" ]]; then
   echo "Existing config found at $CONFIG_FILE:"
   cat "$CONFIG_FILE"
@@ -65,17 +88,14 @@ echo ""
 # --- Check wrangler auth ---
 
 echo "Checking wrangler authentication..."
-if npx wrangler whoami &>/dev/null 2>&1; then
+if wrangler whoami &>/dev/null 2>&1; then
   echo "Wrangler is authenticated."
 else
   echo ""
-  echo "Wrangler is not authenticated. You have two options:"
+  echo "Wrangler is not authenticated."
   echo ""
-  echo "  1. Run: npx wrangler login"
-  echo "     (Interactive OAuth -- opens your browser)"
-  echo ""
-  echo "  2. Set the CLOUDFLARE_API_TOKEN environment variable"
-  echo "     (Create a token at https://dash.cloudflare.com/profile/api-tokens)"
+  echo "Run the following to authorize (opens your browser):"
+  echo "  wrangler login"
   echo ""
 fi
 


### PR DESCRIPTION
## Summary

- Fixed publish skill uploading to a local R2 simulator instead of the remote Cloudflare bucket by adding the required `--remote` flag to all `wrangler r2` commands
- Switched from `npx wrangler` to direct `wrangler` invocation — faster execution, explicit dependency
- Added Wrangler installation check and auto-install prompt to `setup.sh`, plus better error surfacing in `publish.sh`

## Test plan

- [x] Verified `wrangler r2 object put` with `--remote` uploads to the real bucket
- [x] Confirmed public URL returns HTTP 200 after upload
- [x] Validated `history.sh list` and `history.sh search` work correctly
- [ ] Run `setup.sh` on a machine without Wrangler to confirm install prompt works
- [ ] Run `history.sh prune` to confirm `--remote` flag works for object existence checks