### PR TITLE
Harden ship skill: fix ESM, kill force-push, add CHANGELOG.md support

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "0.6.0",
+    "date": "2026-05-16",
+    "pr": null,
+    "changes": {
+      "improvements": [
+        "Ship skill now supports CHANGELOG.md alongside CHANGELOG.json, defaulting to markdown for new projects",
+        "Preflight now fetches and rebases in a single call, eliminating stale remote ref counts",
+        "Changelog writes are idempotent — interrupted runs update the existing draft entry instead of duplicating"
+      ],
+      "fixes": [
+        "Fixed ESM compatibility in changelog scripts (replaced require() with fs.readFileSync)",
+        "Replaced amend + force-push backfill with a two-commit flow to avoid resetting CI status checks",
+        "Quality gate detection now warns explicitly when no package.json is found instead of silently skipping"
+      ]
+    }
+  },
+  {
     "version": "0.5.0",
     "date": "2026-05-16",
     "pr": {

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,7 +2,11 @@
   {
     "version": "0.6.0",
     "date": "2026-05-16",
-    "pr": null,
+    "pr": {
+      "number": 7,
+      "title": "Harden ship skill: fix ESM, kill force-push, add CHANGELOG.md support",
+      "url": "https://github.com/jcottam/agent-resources/pull/7"
+    },
     "changes": {
       "improvements": [
         "Ship skill now supports CHANGELOG.md alongside CHANGELOG.json, defaulting to markdown for new projects",

--- a/skills/engineering/ship/SKILL.md
+++ b/skills/engineering/ship/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ship
-description: Validate a branch, run quality gates, update documentation and changelog, and open a pull request. Use when the user says "ship", "ship this", "open a PR", "prepare a PR", "send this for review", "let's ship it", or any variation of wanting to finalize work and create a pull request.
+description: Validate a branch, run quality gates, update documentation and changelog, and open a pull request. Designed for JavaScript/TypeScript projects; quality gate detection requires package.json. Use when the user says "ship", "ship this", "open a PR", "prepare a PR", "send this for review", "let's ship it", or any variation of wanting to finalize work and create a pull request.
 license: MIT
 metadata:
   author: jcottam
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Ship
@@ -28,9 +28,9 @@ Run `command -v git && command -v gh && command -v jq && command -v node` to che
 
 Then run `gh auth status` to confirm the GitHub CLI is authenticated. If it reports no active account, stop and instruct the user to run `gh auth login` first.
 
-## Step 1 — Git health check
+## Step 1 — Preflight
 
-Run `$SCRIPTS/preflight.sh` and parse the JSON output.
+Run `$SCRIPTS/preflight.sh` and parse the JSON output. This fetches the default branch, rebases, checks for uncommitted changes, counts commits ahead, and detects an existing PR — all in one call.
 
 - If `uncommittedChanges` is `true`, stop and ask the user to commit or stash.
 - If `onDefaultBranch` is `true`, create a new branch:
@@ -38,6 +38,8 @@ Run `$SCRIPTS/preflight.sh` and parse the JSON output.
   - Pick the appropriate prefix from the table below.
   - Generate a short, descriptive slug from the changes (e.g. `feature/add-team-cadence-grid`).
   - Run `git checkout -b <prefix>/<slug>`.
+- If `rebaseStatus` is `"conflicts"`, stop and report the conflicting files from `conflictFiles` to the user. Do not attempt to resolve merge conflicts automatically.
+- If `rebaseStatus` is `"clean"`, proceed.
 - If `commitsAhead` is `0`, stop — there is nothing to ship.
 
 **Branch prefixes:**
@@ -52,16 +54,11 @@ Run `$SCRIPTS/preflight.sh` and parse the JSON output.
 | `test/`     | Adding or updating tests with no production code changes |
 | `perf/`     | Performance improvements                                 |
 
-## Step 2 — Sync with upstream
-
-Run `$SCRIPTS/preflight.sh --rebase` and check `rebaseStatus` in the JSON output.
-
-- `"clean"` — proceed.
-- `"conflicts"` — stop and report the conflicting files from `conflictFiles` to the user. Do not attempt to resolve merge conflicts automatically.
-
-## Step 3 — Quality gates
+## Step 2 — Quality gates
 
 Run `$SCRIPTS/detect-gates.sh` and parse the JSON output. The `gates` array contains each detected gate's `name` and `command`.
+
+- If `noPackageJson` is `true`, warn the user that no quality gates were detected because this does not appear to be a JavaScript/TypeScript project. Ask if they want to proceed without gates or provide manual commands to run.
 
 **Execution rules:**
 
@@ -70,9 +67,9 @@ Run `$SCRIPTS/detect-gates.sh` and parse the JSON output. The `gates` array cont
 - If a fix requires user input or judgment, stop and report the failure with context.
 - If `gates` is empty, skip this step and note it in the final report.
 
-## Step 4 — Documentation
+## Step 3 — Documentation
 
-Review the changes on the branch (`git diff <default-branch>..HEAD`) and update project documentation to reflect anything new, changed, or removed. Follow the `/technical-writer` skill for writing style and structure.
+Review the changes on the branch (`git diff <default-branch>..HEAD`) and update project documentation to reflect anything new, changed, or removed.
 
 **Files to check:**
 
@@ -86,16 +83,20 @@ Review the changes on the branch (`git diff <default-branch>..HEAD`) and update 
 - Read each file first to understand its current structure and voice.
 - Only update sections that are affected by the changes on the branch. Do not rewrite unrelated content.
 - Match the existing heading hierarchy, formatting, and level of detail.
+- Write for a developer audience. Be direct and specific. Avoid marketing language.
 - Use active voice and present tense. Keep sentences under 25 words.
 - Lead with what the user or developer gains, not how the implementation works.
+- Do not document internal implementation details, private functions, or architecture decisions that are only relevant to the current change — those belong in commit messages or PR descriptions, not README/AGENTS.
 - Include practical examples (commands, config snippets, code) for any new capability.
 - Use `code formatting` for commands, variables, and filenames. Use **bold** for UI elements.
 - If neither file needs changes (e.g. a pure refactor with no public-facing impact), skip this step.
 - Commit documentation updates to the current branch before proceeding.
 
-## Step 5 — Changelog
+## Step 4 — Changelog
 
-Run `$SCRIPTS/changelog-bump.sh info` to get the current version.
+Run `$SCRIPTS/changelog-bump.sh info` to get the current version and changelog format.
+
+The script auto-detects the changelog format: it uses `CHANGELOG.json` if one exists, otherwise defaults to `CHANGELOG.md`. The `format` field in the output indicates which format is active.
 
 Decide the bump level based on the changes:
 - `patch` — fixes only
@@ -128,22 +129,22 @@ Then run:
 $SCRIPTS/changelog-bump.sh bump <level> '<changes-json>'
 ```
 
-This creates or updates `CHANGELOG.json` with the new entry (the `pr` field is `null` — it gets back-filled in Step 6).
+If the script output has `"updated": true`, it patched an existing draft entry (from a previous interrupted run) instead of creating a new one.
 
-## Step 6 — Open the PR
+## Step 5 — Open the PR
 
 Use the `prExists` and `pr` fields from the Step 1 preflight output to decide whether to create or update.
 
-1. `git add CHANGELOG.json && git commit -m "chore: add changelog entry"`.
+1. Commit the changelog: `git add CHANGELOG.json CHANGELOG.md 2>/dev/null; git add -u && git commit -m "chore: add changelog entry"`.
 2. `git push -u origin HEAD`.
 3. Create or update the PR:
    - **New PR**: `gh pr create` with a title and body derived from the commit log.
    - **Existing PR**: `gh pr edit` to update the title and body if the changelog or commits have changed. Push any new commits.
    - **Title**: a concise summary of the branch's changes.
    - **Body**: a `## Summary` section with 1-3 bullet points describing the changes, and a `## Test plan` section with a checklist of verification steps.
-4. Run `$SCRIPTS/backfill-pr.sh` to patch the PR metadata into `CHANGELOG.json`, amend the commit, and force-push.
+4. Run `$SCRIPTS/backfill-pr.sh` to patch the PR metadata into the changelog and push a follow-up commit.
 
-## Step 7 — Post-flight report
+## Step 6 — Post-flight report
 
 Print a short summary:
 

--- a/skills/engineering/ship/SKILL.md
+++ b/skills/engineering/ship/SKILL.md
@@ -131,18 +131,24 @@ $SCRIPTS/changelog-bump.sh bump <level> '<changes-json>'
 
 If the script output has `"updated": true`, it patched an existing draft entry (from a previous interrupted run) instead of creating a new one.
 
+After the script completes, amend the changelog into the last work commit so it does not create extra commits:
+
+```
+git add CHANGELOG.json CHANGELOG.md 2>/dev/null; git commit --amend --no-edit
+```
+
 ## Step 5 — Open the PR
 
 Use the `prExists` and `pr` fields from the Step 1 preflight output to decide whether to create or update.
 
-1. Commit the changelog: `git add CHANGELOG.json CHANGELOG.md 2>/dev/null; git add -u && git commit -m "chore: add changelog entry"`.
-2. `git push -u origin HEAD`.
-3. Create or update the PR:
+1. `git push -u origin HEAD`.
+2. Create or update the PR:
    - **New PR**: `gh pr create` with a title and body derived from the commit log.
    - **Existing PR**: `gh pr edit` to update the title and body if the changelog or commits have changed. Push any new commits.
    - **Title**: a concise summary of the branch's changes.
    - **Body**: a `## Summary` section with 1-3 bullet points describing the changes, and a `## Test plan` section with a checklist of verification steps.
-4. Run `$SCRIPTS/backfill-pr.sh` to patch the PR metadata into the changelog and push a follow-up commit.
+
+> **Optional:** Run `$SCRIPTS/backfill-pr.sh` after creating the PR to add a PR link to the changelog entry. This is not run by default — use it if your team wants PR traceability in the changelog.
 
 ## Step 6 — Post-flight report
 

--- a/skills/engineering/ship/scripts/backfill-pr.sh
+++ b/skills/engineering/ship/scripts/backfill-pr.sh
@@ -24,7 +24,7 @@ fi
 
 # --- fetch PR metadata --------------------------------------------------------
 
-PR_DATA=$(gh pr view HEAD --json number,title,url 2>/dev/null || echo "")
+PR_DATA=$(gh pr view --json number,title,url 2>/dev/null || echo "")
 
 if [[ -z "$PR_DATA" ]]; then
   echo '{"error": "No PR found for HEAD"}' >&2

--- a/skills/engineering/ship/scripts/backfill-pr.sh
+++ b/skills/engineering/ship/scripts/backfill-pr.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Back-fills the PR metadata into the newest CHANGELOG.json entry, amends the
-# last commit, and force-pushes.
+# Back-fills the PR metadata into the changelog file, creates a new commit,
+# and pushes.
 #
 # Usage:  backfill-pr.sh
 #
-# Reads PR info from `gh pr view HEAD` — must be run after the PR is created
-# and the changelog commit is HEAD.
+# Reads PR info from `gh pr view HEAD` — must be run after the PR is created.
+# Supports both CHANGELOG.json and CHANGELOG.md.
 
-CHANGELOG="CHANGELOG.json"
+# --- detect changelog format --------------------------------------------------
 
-if [[ ! -f "$CHANGELOG" ]]; then
-  echo '{"error": "CHANGELOG.json not found"}' >&2
+if [[ -f "CHANGELOG.json" ]]; then
+  CHANGELOG="CHANGELOG.json"
+  FORMAT="json"
+elif [[ -f "CHANGELOG.md" ]]; then
+  CHANGELOG="CHANGELOG.md"
+  FORMAT="md"
+else
+  echo '{"error": "No CHANGELOG.json or CHANGELOG.md found"}' >&2
   exit 1
 fi
 
@@ -29,28 +35,38 @@ PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
 PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
 PR_URL=$(echo "$PR_DATA" | jq -r '.url')
 
-# --- patch CHANGELOG.json ----------------------------------------------------
+# --- patch changelog ----------------------------------------------------------
 
-node -e "
-  const fs = require('fs');
-  const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
-  if (cl.length === 0) {
-    console.error('CHANGELOG.json is empty');
-    process.exit(1);
-  }
-  cl[0].pr = {
-    number: $PR_NUMBER,
-    title: $(echo "$PR_TITLE" | jq -R '.'),
-    url: $(echo "$PR_URL" | jq -R '.')
-  };
-  fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
-"
+if [[ "$FORMAT" == "json" ]]; then
+  node -e "
+    const fs = require('fs');
+    const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
+    if (cl.length === 0) {
+      console.error('CHANGELOG.json is empty');
+      process.exit(1);
+    }
+    cl[0].pr = {
+      number: $PR_NUMBER,
+      title: $(echo "$PR_TITLE" | jq -R '.'),
+      url: $(echo "$PR_URL" | jq -R '.')
+    };
+    fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
+  "
+else
+  node -e "
+    const fs = require('fs');
+    let md = fs.readFileSync('$CHANGELOG', 'utf8');
+    const prLink = '([#$PR_NUMBER]($PR_URL))';
+    md = md.replace(/^(## \[[^\]]+\])/m, '\$1 ' + prLink);
+    fs.writeFileSync('$CHANGELOG', md);
+  "
+fi
 
-# --- amend + push -------------------------------------------------------------
+# --- commit + push ------------------------------------------------------------
 
 git add "$CHANGELOG"
-git commit --amend --no-edit
-git push --force-with-lease
+git commit -m "chore: backfill PR metadata"
+git push
 
 # --- output -------------------------------------------------------------------
 

--- a/skills/engineering/ship/scripts/changelog-bump.sh
+++ b/skills/engineering/ship/scripts/changelog-bump.sh
@@ -55,24 +55,23 @@ current_version() {
   fi
 }
 
-# --- check if latest entry is a draft (pr: null / no PR link) ----------------
+# --- check if latest entry matches the target version (interrupted run) ------
 
-latest_is_draft() {
+latest_matches_version() {
+  local target="$1"
   if [[ "$FORMAT" == "json" ]]; then
     node -e "
       const fs = require('fs');
       const cl = JSON.parse(fs.readFileSync('./$CHANGELOG', 'utf8'));
-      const draft = cl.length > 0 && cl[0].pr === null;
-      console.log(draft ? 'true' : 'false');
+      const match = cl.length > 0 && cl[0].version === '$target';
+      console.log(match ? 'true' : 'false');
     "
   else
     node -e "
       const fs = require('fs');
       const md = fs.readFileSync('./$CHANGELOG', 'utf8');
-      const m = md.match(/^## \[([^\]]+)\](.*)/m);
-      if (!m) { console.log('false'); process.exit(0); }
-      const hasLink = /\(#\d+\)/.test(m[2] || '');
-      console.log(hasLink ? 'false' : 'true');
+      const m = md.match(/^## \[([^\]]+)\]/m);
+      console.log(m && m[1] === '$target' ? 'true' : 'false');
     "
   fi
 }
@@ -105,16 +104,15 @@ case "$ACTION" in
     CURRENT=$(current_version)
     NEXT=$(bump_version "$CURRENT" "$LEVEL")
     TODAY=$(date +%Y-%m-%d)
-    IS_DRAFT=$(latest_is_draft)
+    MATCHES=$(latest_matches_version "$NEXT")
     UPDATED=false
 
     if [[ "$FORMAT" == "json" ]]; then
-      if [[ "$IS_DRAFT" == "true" ]]; then
+      if [[ "$MATCHES" == "true" ]]; then
         UPDATED=true
         node -e "
           const fs = require('fs');
           const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
-          cl[0].version = '$NEXT';
           cl[0].date = '$TODAY';
           cl[0].changes = $CHANGES;
           fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
@@ -126,7 +124,6 @@ case "$ACTION" in
           const entry = {
             version: '$NEXT',
             date: '$TODAY',
-            pr: null,
             changes: $CHANGES
           };
           cl.unshift(entry);
@@ -134,7 +131,7 @@ case "$ACTION" in
         "
       fi
     else
-      if [[ "$IS_DRAFT" == "true" ]]; then
+      if [[ "$MATCHES" == "true" ]]; then
         UPDATED=true
         node -e "
           const fs = require('fs');

--- a/skills/engineering/ship/scripts/changelog-bump.sh
+++ b/skills/engineering/ship/scripts/changelog-bump.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Manages CHANGELOG.json: reads the current version, computes the next version,
-# and prepends a new entry skeleton.
+# Manages the project changelog: reads the current version, computes the next
+# version, and prepends a new entry.  Supports both CHANGELOG.json and
+# CHANGELOG.md (defaults to MD when neither exists).
 #
 # Usage:
 #   changelog-bump.sh info                   # print current version + path
@@ -13,22 +14,67 @@ set -euo pipefail
 #
 # Outputs JSON to stdout with the result of the operation.
 
-CHANGELOG="CHANGELOG.json"
 ACTION="${1:-info}"
+
+# --- detect changelog format --------------------------------------------------
+
+if [[ -f "CHANGELOG.json" ]]; then
+  CHANGELOG="CHANGELOG.json"
+  FORMAT="json"
+else
+  CHANGELOG="CHANGELOG.md"
+  FORMAT="md"
+fi
 
 # --- ensure file exists -------------------------------------------------------
 
 if [[ ! -f "$CHANGELOG" ]]; then
-  echo "[]" > "$CHANGELOG"
+  if [[ "$FORMAT" == "json" ]]; then
+    echo "[]" > "$CHANGELOG"
+  else
+    printf "# Changelog\n\nAll notable changes to this project.\n" > "$CHANGELOG"
+  fi
 fi
 
 # --- read current version -----------------------------------------------------
 
 current_version() {
-  node -e "
-    const cl = require('./$CHANGELOG');
-    console.log(cl.length > 0 && cl[0].version ? cl[0].version : '0.0.0');
-  "
+  if [[ "$FORMAT" == "json" ]]; then
+    node -e "
+      const fs = require('fs');
+      const cl = JSON.parse(fs.readFileSync('./$CHANGELOG', 'utf8'));
+      console.log(cl.length > 0 && cl[0].version ? cl[0].version : '0.0.0');
+    "
+  else
+    node -e "
+      const fs = require('fs');
+      const md = fs.readFileSync('./$CHANGELOG', 'utf8');
+      const m = md.match(/^## \[([^\]]+)\]/m);
+      console.log(m ? m[1] : '0.0.0');
+    "
+  fi
+}
+
+# --- check if latest entry is a draft (pr: null / no PR link) ----------------
+
+latest_is_draft() {
+  if [[ "$FORMAT" == "json" ]]; then
+    node -e "
+      const fs = require('fs');
+      const cl = JSON.parse(fs.readFileSync('./$CHANGELOG', 'utf8'));
+      const draft = cl.length > 0 && cl[0].pr === null;
+      console.log(draft ? 'true' : 'false');
+    "
+  else
+    node -e "
+      const fs = require('fs');
+      const md = fs.readFileSync('./$CHANGELOG', 'utf8');
+      const m = md.match(/^## \[([^\]]+)\](.*)/m);
+      if (!m) { console.log('false'); process.exit(0); }
+      const hasLink = /\(#\d+\)/.test(m[2] || '');
+      console.log(hasLink ? 'false' : 'true');
+    "
+  fi
 }
 
 # --- bump version -------------------------------------------------------------
@@ -49,7 +95,8 @@ bump_version() {
 case "$ACTION" in
   info)
     CURRENT=$(current_version)
-    jq -n --arg v "$CURRENT" --arg f "$CHANGELOG" '{ currentVersion: $v, file: $f }'
+    jq -n --arg v "$CURRENT" --arg f "$CHANGELOG" --arg fmt "$FORMAT" \
+      '{ currentVersion: $v, file: $f, format: $fmt }'
     ;;
 
   bump)
@@ -58,25 +105,79 @@ case "$ACTION" in
     CURRENT=$(current_version)
     NEXT=$(bump_version "$CURRENT" "$LEVEL")
     TODAY=$(date +%Y-%m-%d)
+    IS_DRAFT=$(latest_is_draft)
+    UPDATED=false
 
-    node -e "
-      const fs = require('fs');
-      const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
-      const entry = {
-        version: '$NEXT',
-        date: '$TODAY',
-        pr: null,
-        changes: $CHANGES
-      };
-      cl.unshift(entry);
-      fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
-    "
+    if [[ "$FORMAT" == "json" ]]; then
+      if [[ "$IS_DRAFT" == "true" ]]; then
+        UPDATED=true
+        node -e "
+          const fs = require('fs');
+          const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
+          cl[0].version = '$NEXT';
+          cl[0].date = '$TODAY';
+          cl[0].changes = $CHANGES;
+          fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
+        "
+      else
+        node -e "
+          const fs = require('fs');
+          const cl = JSON.parse(fs.readFileSync('$CHANGELOG', 'utf8'));
+          const entry = {
+            version: '$NEXT',
+            date: '$TODAY',
+            pr: null,
+            changes: $CHANGES
+          };
+          cl.unshift(entry);
+          fs.writeFileSync('$CHANGELOG', JSON.stringify(cl, null, 2) + '\n');
+        "
+      fi
+    else
+      if [[ "$IS_DRAFT" == "true" ]]; then
+        UPDATED=true
+        node -e "
+          const fs = require('fs');
+          let md = fs.readFileSync('$CHANGELOG', 'utf8');
+          const changes = $CHANGES;
+          let section = '## [$NEXT] - $TODAY\n';
+          for (const [cat, items] of Object.entries(changes)) {
+            const heading = cat.charAt(0).toUpperCase() + cat.slice(1);
+            section += '\n### ' + heading + '\n\n';
+            for (const item of items) section += '- ' + item + '\n';
+          }
+          md = md.replace(/^## \[[^\]]+\][\s\S]*?(?=^## \[|\Z)/m, section + '\n');
+          fs.writeFileSync('$CHANGELOG', md);
+        "
+      else
+        node -e "
+          const fs = require('fs');
+          let md = fs.readFileSync('$CHANGELOG', 'utf8');
+          const changes = $CHANGES;
+          let section = '## [$NEXT] - $TODAY\n';
+          for (const [cat, items] of Object.entries(changes)) {
+            const heading = cat.charAt(0).toUpperCase() + cat.slice(1);
+            section += '\n### ' + heading + '\n\n';
+            for (const item of items) section += '- ' + item + '\n';
+          }
+          const marker = md.indexOf('## [');
+          if (marker === -1) {
+            md = md.trimEnd() + '\n\n' + section;
+          } else {
+            md = md.slice(0, marker) + section + '\n' + md.slice(marker);
+          }
+          fs.writeFileSync('$CHANGELOG', md);
+        "
+      fi
+    fi
 
     jq -n \
       --arg prev "$CURRENT" \
       --arg next "$NEXT" \
       --arg date "$TODAY" \
-      '{ previousVersion: $prev, newVersion: $next, date: $date }'
+      --arg fmt "$FORMAT" \
+      --argjson updated "$UPDATED" \
+      '{ previousVersion: $prev, newVersion: $next, date: $date, format: $fmt, updated: $updated }'
     ;;
 
   *)

--- a/skills/engineering/ship/scripts/detect-gates.sh
+++ b/skills/engineering/ship/scripts/detect-gates.sh
@@ -9,6 +9,13 @@ set -euo pipefail
 
 ROOT="${1:-.}"
 
+# --- check for package.json --------------------------------------------------
+
+if [[ ! -f "$ROOT/package.json" ]]; then
+  jq -n '{ pm: null, gates: [], noPackageJson: true }'
+  exit 0
+fi
+
 # --- package manager ----------------------------------------------------------
 
 detect_pm() {
@@ -25,7 +32,6 @@ PM=$(detect_pm)
 
 has_script() {
   local name="$1"
-  [[ -f "$ROOT/package.json" ]] || return 1
   node -e "
     const pkg = require('$ROOT/package.json');
     process.exit(pkg.scripts && pkg.scripts['$name'] ? 0 : 1);

--- a/skills/engineering/ship/scripts/preflight.sh
+++ b/skills/engineering/ship/scripts/preflight.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Gathers git state needed by the ship skill and optionally rebases on the
-# default branch.  Outputs a single JSON object to stdout.
+# Gathers git state needed by the ship skill: fetches the default branch,
+# counts commits ahead, checks for an existing PR, and rebases (by default).
+# Outputs a single JSON object to stdout.
 #
 # Usage:
-#   preflight.sh              # health check only
-#   preflight.sh --rebase     # health check + fetch & rebase
+#   preflight.sh              # health check + fetch + rebase (default)
+#   preflight.sh --no-rebase  # health check + fetch only, skip rebase
 
-REBASE=false
+REBASE=true
 for arg in "$@"; do
   case "$arg" in
-    --rebase) REBASE=true ;;
+    --no-rebase) REBASE=false ;;
   esac
 done
 
@@ -46,7 +47,24 @@ else
   HAS_UNCOMMITTED=false
 fi
 
-# --- commits ahead ------------------------------------------------------------
+# --- fetch + rebase -----------------------------------------------------------
+
+git fetch origin "$DEFAULT_BRANCH" --quiet
+
+REBASE_STATUS="skipped"
+CONFLICT_FILES="[]"
+
+if [[ "$REBASE" == true ]]; then
+  if git rebase "origin/$DEFAULT_BRANCH" --quiet 2>/dev/null; then
+    REBASE_STATUS="clean"
+  else
+    REBASE_STATUS="conflicts"
+    CONFLICT_FILES=$(git diff --name-only --diff-filter=U | jq -R -s 'split("\n") | map(select(. != ""))')
+    git rebase --abort 2>/dev/null || true
+  fi
+fi
+
+# --- commits ahead (counted after fetch so the ref is current) ----------------
 
 COMMITS_AHEAD=$(git rev-list --count "origin/$DEFAULT_BRANCH..HEAD" 2>/dev/null || echo 0)
 
@@ -63,22 +81,6 @@ if [[ -n "$PR_JSON" ]]; then
 else
   PR_EXISTS=false
   PR_JSON="null"
-fi
-
-# --- rebase (optional) --------------------------------------------------------
-
-REBASE_STATUS="skipped"
-CONFLICT_FILES="[]"
-
-if [[ "$REBASE" == true ]]; then
-  git fetch origin "$DEFAULT_BRANCH" --quiet
-  if git rebase "origin/$DEFAULT_BRANCH" --quiet 2>/dev/null; then
-    REBASE_STATUS="clean"
-  else
-    REBASE_STATUS="conflicts"
-    CONFLICT_FILES=$(git diff --name-only --diff-filter=U | jq -R -s 'split("\n") | map(select(. != ""))')
-    git rebase --abort 2>/dev/null || true
-  fi
 fi
 
 # --- output -------------------------------------------------------------------

--- a/skills/engineering/ship/scripts/preflight.sh
+++ b/skills/engineering/ship/scripts/preflight.sh
@@ -75,7 +75,7 @@ fi
 
 # --- existing PR --------------------------------------------------------------
 
-PR_JSON=$(gh pr view HEAD --json url,number,title 2>/dev/null || echo "")
+PR_JSON=$(gh pr view --json url,number,title 2>/dev/null || echo "")
 if [[ -n "$PR_JSON" ]]; then
   PR_EXISTS=true
 else


### PR DESCRIPTION
## Summary

- Replaced the amend + force-push backfill pattern with a two-commit flow that avoids resetting CI status checks
- Fixed ESM compatibility (`require()` → `fs.readFileSync`), added CHANGELOG.md support alongside JSON, and made changelog writes idempotent for interrupted runs
- Consolidated preflight into a single call (always fetches before counting commits), declared JS/TS scope in quality gate detection, and removed the cross-skill dependency on `/technical-writer`

## Test plan

- [ ] Run `bash skills/engineering/ship/scripts/preflight.sh` — verify JSON output includes `rebaseStatus: "clean"` and `commitsAhead` is accurate
- [ ] Run `bash skills/engineering/ship/scripts/detect-gates.sh` in a non-JS repo — verify `noPackageJson: true` is returned
- [ ] Run `bash skills/engineering/ship/scripts/changelog-bump.sh info` — verify format detection works for both JSON and MD
- [ ] Run `bash skills/engineering/ship/scripts/changelog-bump.sh bump minor '{"features":["test"]}'` twice — verify second run updates instead of duplicating
- [ ] Run the full ship skill on a JS/TS project to verify end-to-end flow