### PR TITLE
feat: add sounding-board skill for collaborative thinking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "1.0.0",
   "author": { "name": "jcottam" },
   "license": "MIT",
-  "skills": ["./skills/design/content-wireframe", "./skills/engineering/orient", "./skills/engineering/ship", "./skills/engineering/review-pr", "./skills/thinking/advisor", "./skills/publishing/host"]
+  "skills": ["./skills/design/content-wireframe", "./skills/engineering/orient", "./skills/engineering/ship", "./skills/engineering/review-pr", "./skills/thinking/advisor", "./skills/thinking/sounding-board", "./skills/publishing/host"]
 }

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "0.10.0",
+    "date": "2026-06-02",
+    "changes": {
+      "features": [
+        "Added sounding-board skill — an opinionated rubber duck that reflects ideas back, flags gaps, and offers concrete suggestions one exchange at a time"
+      ]
+    }
+  },
+  {
     "version": "0.9.0",
     "date": "2026-06-02",
     "changes": {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ npx skills update
 | Skill | Description |
 |-------|-------------|
 | [advisor](./skills/thinking/advisor/SKILL.md) | Rigorous, no-nonsense advisory mode. Eliminates sycophancy, enforces intellectual honesty, and produces thorough analysis with explicit confidence levels. |
+| [sounding-board](./skills/thinking/sounding-board/SKILL.md) | Opinionated rubber duck that reflects your thinking back, flags gaps, and offers suggestions one exchange at a time. |
 
 ---
 

--- a/skills/thinking/sounding-board/SKILL.md
+++ b/skills/thinking/sounding-board/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: sounding-board
+description: >-
+  Opinionated rubber duck. Reflects the user's thinking back in plain language,
+  flags gaps, and offers concrete suggestions -- one exchange at a time. Use
+  when the user says "bounce this off you", "think with me", "sounding board",
+  "talk this through", "what do you think", or wants collaborative feedback on
+  an idea, plan, or design.
+---
+
+Restate my idea in your own words so I can hear it fresh, then flag anything that sounds fuzzy, contradictory, or underspecified. After that, give your concrete opinion or suggestion on what I should do.
+
+Go one exchange at a time. Don't pile up questions -- respond to what I just said before moving on.
+
+If a question can be answered by exploring the codebase, explore the codebase instead of asking me.


### PR DESCRIPTION
## Summary

- Added **sounding-board** skill — an opinionated rubber duck that reflects the user's thinking back in plain language, flags gaps, and offers concrete suggestions one exchange at a time.
- Registered skill in `.claude-plugin/plugin.json` and README skills table.

## Test plan

- [ ] Verify `skills/thinking/sounding-board/SKILL.md` is well-formed and frontmatter parses correctly
- [ ] Confirm skill appears in `.claude-plugin/plugin.json`
- [ ] Confirm skill appears in the README Thinking table
- [ ] Confirm changelog entry for 0.10.0