### PR TITLE
feat: add handoff skill for session context compaction

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,5 @@
   "version": "1.0.0",
   "author": { "name": "jcottam" },
   "license": "MIT",
-  "skills": ["./skills/design/content-wireframe", "./skills/engineering/orient", "./skills/engineering/ship", "./skills/engineering/review-pr", "./skills/thinking/advisor", "./skills/thinking/sounding-board", "./skills/publishing/host"]
+  "skills": ["./skills/design/content-wireframe", "./skills/engineering/orient", "./skills/engineering/ship", "./skills/engineering/review-pr", "./skills/productivity/handoff", "./skills/thinking/advisor", "./skills/thinking/sounding-board", "./skills/publishing/host"]
 }

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -9,6 +9,11 @@
       "improvements": [
         "Handoff supports artifact deduplication, next-session focus via argument-hint, suggested skills on resume, and PII redaction"
       ]
+    },
+    "pr": {
+      "number": 13,
+      "title": "feat: add handoff skill for session context compaction",
+      "url": "https://github.com/jcottam/agent-resources/pull/13"
     }
   },
   {

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.11.0",
+    "date": "2026-06-02",
+    "changes": {
+      "features": [
+        "Added handoff skill to compact session context into ~/.agents/handoffs/ for continuation across agent turns"
+      ],
+      "improvements": [
+        "Handoff supports artifact deduplication, next-session focus via argument-hint, suggested skills on resume, and PII redaction"
+      ]
+    }
+  },
+  {
     "version": "0.10.0",
     "date": "2026-06-02",
     "changes": {

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ npx skills update
 |-------|-------------|
 | [host](./skills/publishing/host/SKILL.md) | Upload files to Cloudflare R2 and return a shareable public URL with slug naming, clipboard copy, and hosting history. |
 
+### Productivity
+
+| Skill | Description |
+|-------|-------------|
+| [handoff](./skills/productivity/handoff/SKILL.md) | Compact session context into `~/.agents/handoffs/` with deduped artifact references, next-session focus, and suggested skills for resume. |
+
 ### Thinking
 
 | Skill | Description |

--- a/skills/productivity/handoff/SKILL.md
+++ b/skills/productivity/handoff/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: handoff
+description: >-
+  Compact a chat session or task into a curated markdown handoff file under
+  ~/.agents/handoffs/ for continuation in a new agent turn or chat. References
+  existing plans and PRDs by path instead of duplicating them; optional next-session
+  focus via arguments. Use when the user says handoff, compact context, resume
+  handoff, continue session, carry over context, checkpoint, or start fresh with
+  prior work. Not the content-wireframe implementer handoff.
+license: MIT
+metadata:
+  author: jcottam
+  version: "1.1.0"
+disable-model-invocation: true
+argument-hint: What will the next session be used for?
+---
+
+# Handoff
+
+Editorially compress session context into a small markdown checkpoint an agent
+can load in a new turn. Raw transcripts live under Cursor project folders;
+handoffs are **curated, short, and decision-dense**.
+
+`SCRIPTS` refers to the `scripts/` directory next to this file.
+`HANDOFFS_ROOT` is `~/.agents/handoffs/`.
+
+This skill is **not** the content-wireframe "Handoff" (approved copy →
+implementer). It is **session/task continuity** across chats or agents.
+
+## Choose mode
+
+| User intent | Mode |
+|-------------|------|
+| handoff, compact, checkpoint, save context, done for today | **Create** |
+| resume handoff, continue from handoff, load handoff, `@` handoff file | **Resume** |
+
+If ambiguous, ask once which mode they want.
+
+---
+
+## Create
+
+### Phase 0 — Eligibility
+
+Skip creating a handoff (tell the user why) if **all** are true:
+
+- The task is fully done with nothing left to continue
+- There are no decisions, partial state, or open questions worth preserving
+- A PR/commit message or one sentence is enough (`ship` may be better)
+
+### Phase 1 — Gather inputs
+
+Collect signal in this order. Do **not** paste tool dumps or transcript chunks
+into the handoff file.
+
+1. User goal and latest instructions
+2. **Next session focus** — if the user passed slash/command arguments or
+   stated what the next chat is for, treat that as the primary lens for
+   **Next steps** and **Suggested skills**
+3. Run `$SCRIPTS/workspace-id.sh` and parse JSON (`workspace_path`,
+   `workspace_id`, `git_head`)
+4. If git repo: `git status -sb`, `git diff --stat` (and branch name)
+5. Files the user `@` mentioned or the agent edited this session
+6. Explicit **decisions** and **reversals** from the conversation
+7. Open questions, blockers, and **failed approaches** (do not redo)
+8. **Existing artifacts** — scan for PRDs, specs, plans, ADRs, issues, open
+   PRs, and large on-disk docs. Note paths only; do not copy their contents
+   into the handoff (see deduplication below)
+
+### Phase 2 — Write
+
+**Slug:** from user input, next session focus, or 3–5 words from the goal
+(kebab-case).
+
+**Deduplication:** Do not duplicate content already captured in workspace
+artifacts (PRDs, specs, plans, ADRs, issues, commit messages, or large diffs).
+Reference by path or URL; at most one line summarizing why that artifact matters.
+Never paste plan bodies, issue threads, or diff hunks into the handoff.
+
+**Paths:**
+
+```
+$HANDOFFS_ROOT/<workspace_id>/<ISO8601-local>-<slug>.md
+$HANDOFFS_ROOT/<workspace_id>/latest.md   # copy of the same content
+```
+
+Create `$HANDOFFS_ROOT/<workspace_id>/` if missing.
+
+**Budget:** ≤120 lines (~2,500 words). Cut exploration narrative first, then
+artifact detail. Never cut **Next steps** or **Do not redo**.
+
+**Redaction (before write):** Remove API keys, tokens, `.env` values,
+passwords, and personally identifiable information. Use `[REDACTED]`. When
+unsure, omit the line.
+
+Use this template:
+
+```markdown
+---
+handoff_version: 1
+created_at: 2026-06-02T14:30:22-05:00
+workspace_path: /absolute/path/to/project
+workspace_id: agent-resources-a3f9c2e1b4d0
+git_head: abc123def456789...
+source: cursor-chat
+supersedes: null
+---
+
+# Handoff: [short title]
+
+## Goal
+
+[One sentence]
+
+## Next session focus
+
+[What the next chat is for — from user args or conversation. Omit this section
+if not provided.]
+
+## Current state
+
+- Branch: ...
+- Status: [what is done / in progress]
+- Key changes: [files or areas touched]
+
+## Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| ... | ... |
+
+## Verified facts
+
+- [Things confirmed in repo, docs, or commands]
+
+## Assumptions
+
+- [Guesses not yet verified — label clearly]
+
+## Constraints
+
+- [User rules, repo conventions, explicit "do not"]
+
+## Do not redo
+
+- [Approach X failed because Y — do not retry unless user asks]
+
+## Open questions
+
+- [ ] ...
+
+## Next steps
+
+1. ...
+2. ...
+
+## Suggested skills
+
+[List 0–3 installed skills the next agent should consider invoking, each with
+one line why. Only skills that match **Next session focus** or **Next steps**.
+Use skill `name` from frontmatter (e.g. `ship`, `review-pr`). Omit section if
+none apply.]
+
+## Artifacts
+
+- `path/to/file` — why it matters (reference only; no duplicated content)
+- PR/issue URL if any
+```
+
+Set `supersedes` to the prior handoff path when continuing a multi-session task.
+
+### Phase 3 — Verify and report
+
+1. Count lines; trim if over budget
+2. Copy the file to `latest.md` in the same `workspace_id` folder
+3. Tell the user:
+   - Absolute path to the timestamped file
+   - That `latest.md` was updated
+   - To attach with `@` or say **resume handoff** in the next chat
+4. Note: handoffs are not auto-deleted; prune old files manually if needed
+
+---
+
+## Resume
+
+### Phase 1 — Load
+
+1. If the user `@` a specific `.md` file, read that file
+2. Else run `$SCRIPTS/workspace-id.sh`, then read:
+   `$HANDOFFS_ROOT/<workspace_id>/latest.md`
+3. If `latest.md` is missing, list `$HANDOFFS_ROOT/<workspace_id>/` and ask
+   which file to use
+
+### Phase 2 — Validate
+
+1. Compare `workspace_path` in frontmatter to `$SCRIPTS/workspace-id.sh`
+   output. If they differ, warn and ask whether to trust the handoff or
+   re-audit the repo
+2. If `git_head` is set and the repo has git: compare to current
+   `git rev-parse HEAD`. If they differ, say the repo moved on and ask
+   whether to trust handoff state or re-gather git status
+3. This handoff does **not** replace `AGENTS.md`, `.cursor/rules/`, or user
+   rules — read those before implementing code if relevant
+
+### Phase 3 — Continue
+
+In one short message: restate **Goal** (and **Next session focus** if present)
+and **Next step 1**, then execute. Do not parrot the entire file. Work from
+**Next steps** in order; respect **Do not redo** and **Constraints**.
+
+If **Suggested skills** lists skills, read and follow those skill files when
+their scope matches the current task — do not invoke them blindly if the work
+has diverged.
+
+---
+
+## Utility script
+
+**workspace-id.sh** — stable paths for handoff storage:
+
+```bash
+$SCRIPTS/workspace-id.sh
+$SCRIPTS/workspace-id.sh /path/to/workspace
+```
+
+Example output:
+
+```json
+{
+  "workspace_path": "/Users/me/apps/agent-resources",
+  "workspace_id": "agent-resources-a3f9c2e1b4d0",
+  "git_head": "abc123..."
+}
+```
+
+`git_head` is `null` when not inside a git repository.

--- a/skills/productivity/handoff/scripts/workspace-id.sh
+++ b/skills/productivity/handoff/scripts/workspace-id.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolves stable workspace identity for handoff files.
+# Outputs a single JSON object to stdout.
+#
+# Usage:
+#   workspace-id.sh              # use current directory (or git root)
+#   workspace-id.sh /path/to/dir # resolve from explicit path
+
+abspath() {
+  local dir="$1"
+  if dir=$(cd "$dir" && pwd -P 2>/dev/null); then
+    printf '%s' "$dir"
+  else
+    cd "$dir" && pwd
+  fi
+}
+
+TARGET=$(abspath "${1:-.}")
+
+WORKSPACE_PATH="$TARGET"
+if git -C "$TARGET" rev-parse --is-inside-work-tree &>/dev/null; then
+  WORKSPACE_PATH=$(abspath "$(git -C "$TARGET" rev-parse --show-toplevel)")
+fi
+
+BASENAME=$(basename "$WORKSPACE_PATH")
+
+if command -v shasum &>/dev/null; then
+  HASH=$(printf '%s' "$WORKSPACE_PATH" | shasum -a 256 | awk '{print $1}' | cut -c1-12)
+elif command -v openssl &>/dev/null; then
+  HASH=$(printf '%s' "$WORKSPACE_PATH" | openssl dgst -sha256 | awk '{print $2}' | cut -c1-12)
+else
+  echo '{"error":"shasum or openssl required to compute workspace_id"}' >&2
+  exit 1
+fi
+
+WORKSPACE_ID="${BASENAME}-${HASH}"
+
+GIT_HEAD=""
+if git -C "$WORKSPACE_PATH" rev-parse HEAD &>/dev/null; then
+  GIT_HEAD=$(git -C "$WORKSPACE_PATH" rev-parse HEAD)
+fi
+
+export WORKSPACE_PATH WORKSPACE_ID GIT_HEAD
+python3 - <<'PY'
+import json, os
+
+git_head = os.environ.get("GIT_HEAD") or None
+if git_head == "":
+    git_head = None
+
+print(json.dumps({
+    "workspace_path": os.environ["WORKSPACE_PATH"],
+    "workspace_id": os.environ["WORKSPACE_ID"],
+    "git_head": git_head,
+}, indent=2))
+PY


### PR DESCRIPTION
## Summary

- Adds **handoff** productivity skill to compact chat/session context into curated markdown under `~/.agents/handoffs/`
- Includes `workspace-id.sh` for stable workspace keys, create/resume workflows, line budget, and git staleness checks
- Supports artifact deduplication, `argument-hint` next-session focus, suggested skills in the output doc, and PII redaction

## Test plan

- [ ] Run `skills/productivity/handoff/scripts/workspace-id.sh` and confirm JSON output
- [ ] Invoke handoff create in a test chat; verify file under `~/.agents/handoffs/<workspace_id>/`
- [ ] Resume handoff in a new chat via `@latest.md` or "resume handoff"
- [ ] `npx skills@latest add jcottam/agent-resources/skills/productivity/handoff` installs cleanly