### PR TITLE
improve: handoff v1.2 with fidelity, TL;DR, and session activity

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -6,6 +6,11 @@
       "improvements": [
         "Handoff v1.2 adds compaction fidelity warnings, TL;DR, condensed session activity, search tags, quantifiable artifacts, and bash-backed timestamps"
       ]
+    },
+    "pr": {
+      "number": 14,
+      "title": "improve: handoff v1.2 with fidelity, TL;DR, and session activity",
+      "url": "https://github.com/jcottam/agent-resources/pull/14"
     }
   },
   {

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "0.11.1",
+    "date": "2026-06-12",
+    "changes": {
+      "improvements": [
+        "Handoff v1.2 adds compaction fidelity warnings, TL;DR, condensed session activity, search tags, quantifiable artifacts, and bash-backed timestamps"
+      ]
+    }
+  },
+  {
     "version": "0.11.0",
     "date": "2026-06-02",
     "changes": {

--- a/skills/productivity/handoff/SKILL.md
+++ b/skills/productivity/handoff/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: MIT
 metadata:
   author: jcottam
-  version: "1.1.0"
+  version: "1.2.0"
 disable-model-invocation: true
 argument-hint: What will the next session be used for?
 ---
@@ -66,28 +66,60 @@ into the handoff file.
 8. **Existing artifacts** — scan for PRDs, specs, plans, ADRs, issues, open
    PRs, and large on-disk docs. Note paths only; do not copy their contents
    into the handoff (see deduplication below)
+9. **Session activity** — condensed outcomes from tool use this session (files
+   written, commands run and key results, PRs opened, tests pass/fail counts).
+   Outcomes only; no raw stdout or play-by-play
 
 ### Phase 2 — Write
 
+**Timestamps and filename:** Do not invent times. Run bash before writing:
+
+```bash
+date +%Y-%m-%dT%H:%M:%S%z    # created_at in frontmatter
+date +%Y-%m-%d                  # date in frontmatter
+date +%H:%M                     # time in frontmatter
+```
+
 **Slug:** from user input, next session focus, or 3–5 words from the goal
-(kebab-case).
+(kebab-case). Sanitize for filenames — omit `: / \ # ^ [ ] |` and spaces.
+
+**Fidelity:** Set frontmatter `fidelity`:
+
+- `full` — handoff built from complete session context in the current turn
+- `partial-reconstruction` — earliest chat context was compacted or missing;
+  some sections are reconstructed from inference, not verbatim memory
+
+If `partial-reconstruction`, add this block immediately after the `# Handoff:`
+heading (before **TL;DR**):
+
+```markdown
+> **Context warning:** Portions of this handoff were reconstructed from
+> compacted or missing session context. Treat **Assumptions** and uncited claims
+> as unverified until confirmed in the repo or artifacts.
+```
+
+Never present reconstructed content as verified fact — move uncertain items to
+**Assumptions**.
 
 **Deduplication:** Do not duplicate content already captured in workspace
 artifacts (PRDs, specs, plans, ADRs, issues, commit messages, or large diffs).
 Reference by path or URL; at most one line summarizing why that artifact matters.
 Never paste plan bodies, issue threads, or diff hunks into the handoff.
 
-**Paths:**
+**Paths:** Use the real timestamp from `date` in the filename:
 
 ```
-$HANDOFFS_ROOT/<workspace_id>/<ISO8601-local>-<slug>.md
+$HANDOFFS_ROOT/<workspace_id>/<YYYY-MM-DD>T<HHMMSS>-<slug>.md
 $HANDOFFS_ROOT/<workspace_id>/latest.md   # copy of the same content
 ```
+
+Example: `2026-06-02T143022-ship-handoff.md`
 
 Create `$HANDOFFS_ROOT/<workspace_id>/` if missing.
 
 **Budget:** ≤120 lines (~2,500 words). Cut exploration narrative first, then
-artifact detail. Never cut **Next steps** or **Do not redo**.
+session activity detail, then artifact detail. Never cut **TL;DR**, **Next
+steps**, or **Do not redo**.
 
 **Redaction (before write):** Remove API keys, tokens, `.env` values,
 passwords, and personally identifiable information. Use `[REDACTED]`. When
@@ -97,16 +129,27 @@ Use this template:
 
 ```markdown
 ---
-handoff_version: 1
-created_at: 2026-06-02T14:30:22-05:00
+handoff_version: 2
+title: Short Title
+date: 2026-06-02
+time: "14:30"
+created_at: 2026-06-02T14:30:22-0400
 workspace_path: /absolute/path/to/project
 workspace_id: agent-resources-a3f9c2e1b4d0
 git_head: abc123def456789...
+fidelity: full
 source: cursor-chat
+tags: [handoff, topic-one, topic-two]
 supersedes: null
 ---
 
 # Handoff: [short title]
+
+## TL;DR
+
+[3–4 sentences max: what this session was about, what was decided or produced,
+and open loops. Write so a future search reveals whether this is the right
+handoff. Do not duplicate **Next steps** verbatim.]
 
 ## Goal
 
@@ -122,6 +165,13 @@ if not provided.]
 - Branch: ...
 - Status: [what is done / in progress]
 - Key changes: [files or areas touched]
+
+## Session activity (condensed)
+
+[Outcomes-only digest of meaningful tool/session work — not a transcript.
+Bullet list: files created/edited, commands and key results, PRs/issues touched,
+tests run and pass/fail counts. Omit raw stdout. Omit section if nothing
+concrete happened beyond conversation.]
 
 ## Decisions
 
@@ -165,9 +215,13 @@ none apply.]
 
 - `path/to/file` — why it matters (reference only; no duplicated content)
 - PR/issue URL if any
+- **Quantifiable facts** not stored in linked files: version numbers, error
+  codes, test counts, env var names, config keys, metric values
 ```
 
 Set `supersedes` to the prior handoff path when continuing a multi-session task.
+Set `tags` to 2–5 lowercase hyphenated topics for search (always include
+`handoff`). Set `title` to match the `# Handoff:` heading.
 
 ### Phase 3 — Verify and report
 
@@ -199,13 +253,15 @@ Set `supersedes` to the prior handoff path when continuing a multi-session task.
 2. If `git_head` is set and the repo has git: compare to current
    `git rev-parse HEAD`. If they differ, say the repo moved on and ask
    whether to trust handoff state or re-gather git status
-3. This handoff does **not** replace `AGENTS.md`, `.cursor/rules/`, or user
+3. If frontmatter `fidelity` is `partial-reconstruction`, treat **Verified
+   facts** skeptically and re-verify before acting on them
+4. This handoff does **not** replace `AGENTS.md`, `.cursor/rules/`, or user
    rules — read those before implementing code if relevant
 
 ### Phase 3 — Continue
 
-In one short message: restate **Goal** (and **Next session focus** if present)
-and **Next step 1**, then execute. Do not parrot the entire file. Work from
+In one short message: restate **TL;DR** or **Goal** (and **Next session focus**
+if present) and **Next step 1**, then execute. Do not parrot the entire file. Work from
 **Next steps** in order; respect **Do not redo** and **Constraints**.
 
 If **Suggested skills** lists skills, read and follow those skill files when


### PR DESCRIPTION
## Summary

- Bumps handoff skill to v1.2.0 with template `handoff_version: 2`
- Adds compaction fidelity warnings (`full` vs `partial-reconstruction`)
- Adds TL;DR, condensed session activity, search frontmatter (`title`, `tags`), quantifiable artifacts guidance, and bash-backed timestamps

## Test plan

- [ ] Create a handoff in a test chat; verify frontmatter fields and filename use real `date` output
- [ ] Confirm `fidelity: partial-reconstruction` shows context warning when applicable
- [ ] Resume handoff in a new chat via `@latest.md`
- [ ] Verify handoff stays within ~120 line budget